### PR TITLE
specify type, as assertion is failing on list

### DIFF
--- a/assignment3/Assignment3.ipynb
+++ b/assignment3/Assignment3.ipynb
@@ -663,6 +663,7 @@
         "    \"\"\"Returns the value of rosenbrock's function and its gradient at x\n",
         "    \"\"\"\n",
         "    val = TODO\n",
+        "    # Gradient should be np.array\n",
         "    dVdX= TODO\n",
         "    return [val, dVdX]\n",
         "\n",


### PR DESCRIPTION
The external function is failing on the correct gradient if one is given in a list, thus I've added the comment specifying the type that passes through assertion.